### PR TITLE
Marker: Fix empty Homography bug

### DIFF
--- a/src/Marker.cpp
+++ b/src/Marker.cpp
@@ -284,6 +284,9 @@ Marker::UpdateContentBasic(vector<PointDouble> &_marker_corners_img,
 	marker_points_img.resize(marker_points.size());
 	cam->Undistort(marker_corners_img_undist);
 	H.Find(marker_corners, marker_corners_img_undist);
+	if (H.H.empty()) {
+		return false;
+	}
 	H.ProjectPoints(marker_points, marker_points_img);
 	cam->Distort(marker_points_img);
 	// Read the content


### PR DESCRIPTION
The port to opencv introduced a bug, where an empty Homography would be
returned and later used for transforms, which would obviously fail.
This catches that bug and return false in that case.

EDIT: tried and tested on Robotino 3 tag vision plugin